### PR TITLE
Nachladefunktion und Schussrate hinzugefügt

### DIFF
--- a/neues-spiel/project.godot
+++ b/neues-spiel/project.godot
@@ -51,6 +51,11 @@ shoot={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+reload={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/neues-spiel/weapon/bullet.gd
+++ b/neues-spiel/weapon/bullet.gd
@@ -2,13 +2,10 @@ class_name Bullet
 extends CharacterBody2D
 
 @export var hitbox_component: HitboxComponent
-
 @export var speed: float = 350.0
 @export var damage: float = 5.0
 @export var max_pierce: int = 1
-
 var current_pierce_count: int = 0
-
 
 func _ready():
 	if hitbox_component:

--- a/neues-spiel/weapon/gun.gd
+++ b/neues-spiel/weapon/gun.gd
@@ -1,14 +1,27 @@
 class_name Gun
 extends Node2D
 
+@export var current_ammo: int = 0:
+	set(amount):
+		current_ammo = amount
+		ammo_label.text = str(amount)
+@export var max_ammo: int = 10
+@export var fire_rate: float = 0.0
+@export var maximum_fire_rate: float = 1.0
+@export var reload_time: float = 1.0
+@onready var ammo_label: Label = $AmmoLabel
 @onready var muzzle: Marker2D = $Marker2D
 @onready var player: Player = get_parent()
+@onready var reload_timer: Timer = $ReloadTimer
+@onready var shoot_timer: Timer = $ShootTimer
 
 var bullet = preload("res://weapon/bullet.tscn")
 var bullet_upgrades: Array[BaseBulletUpgrade] = []
 
 func _ready() -> void:
-	pass # Replace with function body.
+	# connect reload_timer signal to refill_ammo function, also call it at the start
+	reload_timer.timeout.connect(refill_ammo)
+	refill_ammo()
 
 func _physics_process(_delta: float) -> void:
 	# rotate gun towards mouse position
@@ -20,13 +33,45 @@ func _physics_process(_delta: float) -> void:
 	else:
 		scale.y = 1
 
-	# shoot a bullet
+	# check inputs
+	# do nothing when currently reloading
+	if reload_timer.time_left > 0:
+		return
+
+	# shoot a bullet if current_ammo is greater than 0
 	if Input.is_action_just_pressed("shoot"):
-		var bullet_instance = bullet.instantiate()
-		get_tree().root.add_child(bullet_instance)
-		bullet_instance.global_position = self.muzzle.global_position
-		bullet_instance.rotation = self.rotation
-		
-		# loop over all bullet upgrades and apply
-		for upgrade in bullet_upgrades:
-			upgrade.apply_upgrade(bullet_instance)
+		print("current_ammo:", current_ammo)
+		if current_ammo > 0:
+			print("Shoot")
+			shoot_bullet()
+	# reload weapon if not shooting and current_ammo is not equal to max_ammo
+	elif Input.is_action_just_pressed("reload") and current_ammo < max_ammo:
+		print("Reload")
+		reload_ammo()
+
+# shoot a bullet if gun is ready to fire again
+func shoot_bullet() -> void:
+	# do nothing if shoot_timer is running
+	if shoot_timer.time_left > 0:
+		return
+	# shoot bullet with all of its upgrades
+	current_ammo -= 1
+	var bullet_instance: Bullet = bullet.instantiate()
+	get_tree().root.add_child(bullet_instance)
+	bullet_instance.global_position = self.muzzle.global_position
+	bullet_instance.rotation = self.rotation
+	# loop over all bullet upgrades and apply
+	for upgrade in bullet_upgrades:
+		upgrade.apply_upgrade(bullet_instance)
+	# start timer for fire rate, the higher the fire_rate, the faster it shoots
+	shoot_timer.start(maximum_fire_rate - fire_rate)
+
+# reload the ammo visually
+func reload_ammo() -> void:
+	# start reload timer
+	reload_timer.start(reload_time)
+	# TODO: add some animation for the reload process
+
+# fills the current_ammo after reload_timer finishes and sends a signal
+func refill_ammo() -> void:
+	current_ammo = max_ammo

--- a/neues-spiel/weapon/gun.tscn
+++ b/neues-spiel/weapon/gun.tscn
@@ -13,3 +13,17 @@ texture = ExtResource("1_x77fm")
 
 [node name="Marker2D" type="Marker2D" parent="."]
 position = Vector2(51, 0)
+
+[node name="ReloadTimer" type="Timer" parent="."]
+one_shot = true
+
+[node name="ShootTimer" type="Timer" parent="."]
+one_shot = true
+
+[node name="AmmoLabel" type="Label" parent="."]
+offset_left = 16.0
+offset_top = -24.0
+offset_right = 40.0
+offset_bottom = -1.0
+horizontal_alignment = 1
+vertical_alignment = 1


### PR DESCRIPTION
- mit R nachladen (währenddessen kann man nicht schießen)
- Anzahl der Schüsse momentan über der Waffe angezeigt
- man hat unendlich Schüsse zum nachladen, aber maximal 10 Schüsse im Magazin
- Schussrate vorhanden (je höher die Schussrate, desto schneller schießt man)

Einziges Bedenken was ich hatte, ist die Schussrate in der Waffe zu speichern und nicht in der Bullet. Dadurch müsste man eben auch Upgrades für die Waffe haben und nicht nur für die Bullet. Gerne mal schreiben was ihr schlauer findet: Schussrate in der Waffe oder in der Bullet implementieren.